### PR TITLE
add anti_aliasing for scale_factor < 1.0, and use rescale instead of …

### DIFF
--- a/fracatal/scripts.py
+++ b/fracatal/scripts.py
@@ -7,8 +7,6 @@ from fracatal.functional_jax import make_update_step, pad_2d
 import matplotlib
 import matplotlib.pyplot as plt
 
-import time
-
 def v_stability_sweep(pattern, make_kernel, my_update, \
             min_dt=0.001, max_dt=1.05, \
             min_kr=5, max_kr=51,k0=13,\

--- a/fracatal/scripts.py
+++ b/fracatal/scripts.py
@@ -7,6 +7,8 @@ from fracatal.functional_jax import make_update_step, pad_2d
 import matplotlib
 import matplotlib.pyplot as plt
 
+import time
+
 def v_stability_sweep(pattern, make_kernel, my_update, \
             min_dt=0.001, max_dt=1.05, \
             min_kr=5, max_kr=51,k0=13,\
@@ -52,7 +54,11 @@ def v_stability_sweep(pattern, make_kernel, my_update, \
     dim_h = int(native_dim_h * scale_factor)
     dim_w = int(native_dim_w * scale_factor)
     
-    scaled_pattern = np.array(skimage.transform.resize(pattern, (1,1, dim_h, dim_w)), dtype=default_dtype)
+    if scale_factor < 1.0:
+      scaled_pattern = np.array(skimage.transform.rescale(pattern, (1,1, scale_factor, scale_factor), order=5, anti_aliasing=True), \
+          dtype=default_dtype)
+    else:
+      scaled_pattern = np.array(skimage.transform.rescale(pattern, (1,1, scale_factor, scale_factor), order=5), dtype=default_dtype)
     
     starting_grid = starting_grid.at[:,kk:kk+1,:scaled_pattern.shape[-2], :scaled_pattern.shape[-1]].set(scaled_pattern)
    
@@ -94,6 +100,7 @@ def v_stability_sweep(pattern, make_kernel, my_update, \
     
     total_steps_counter = 0
     
+    grid_0 = 1.0 * grid
     while accumulated_t_part.min() < max_t and total_steps_counter <= max_steps:
        
       grid = update_step(grid)
@@ -125,7 +132,7 @@ def v_stability_sweep(pattern, make_kernel, my_update, \
     
   # accumulated_t can be larger than max_t when a batch contains different dt values
   results_img = np.array((255 * results_img), dtype=np.uint8)
-  return results_img, accumulated_t, total_steps, explode, vanish, done
+  return results_img, accumulated_t, total_steps, explode, vanish, done, grid_0, grid
 
 
 def stability_sweep(pattern, make_kernel, my_update, 
@@ -254,7 +261,6 @@ def v_stability_sweep_sl():
   
   kernel = make_kernel(2)
   
-  t0 = time.time()
   
   #my_update = gen
   #per_update = per


### PR DESCRIPTION
…resize with order 5

using a high order for spline interpolation seems to explain strange behavior where simulation with very fine difference in kr leads to 100X or more shorter run times. I suspect this is because the patterns with lower order interpolation rescales are identical, and JIT compilation rightly ignores redundant computation of convolutions over those channels

Peculiar speedup for fine zooms described in Issue #14 

"""
Sometimes simulation is extremely fast--to the point of conspicuity--at fine zooms. Given a ~100X speedup in cases like the example below, is the simulation even running?

```
total elapsed: 112.139 s, last sweep: 112.139
    dt from 2.10e-01 to 2.20e-01
    kr from 1.450000e+01 to 1.50e+01
```
and then 
```
total elapsed: 113.936 s, last sweep: 0.809
    dt from 2.17e-01 to 2.18e-01
    kr from 1.465000e+01 to 1.47e+01
```
"""

Running the same set of conditions with `skimage.transform.resize` replaced with `skimage.transform.rescale` with spline interpolation order of 5 results in more similar simulation runtimes. 

```
total elapsed: 117.064 s, last sweep: 117.064
    dt from 2.10e-01 to 2.20e-01
    kr from 1.450000e+01 to 1.50e+01
```

```
total elapsed: 229.913 s, last sweep: 111.149
    dt from 2.17e-01 to 2.18e-01
    kr from 1.465000e+01 to 1.47e+01
```